### PR TITLE
Initial Whitelist Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ You can exclude notifications from certain namespaces / articles by adding them 
 $wgSlackExcludeNotificationsFrom = ["User:", "Weirdgroup"];
 ```
 
+### Enable notifications from certain pages / namespaces
+
+You can whitelist notifications from certain namespaces / articles by adding them into this array. Note: This targets all pages starting with the name. ALL Other notifications will be discarded, When active, the previously listed exclusion array will further limit this whitelist.
+
+```php
+// Actions (add, edit, modify) will be notified to Slack room from articles starting with these names
+$wgSlackIncludeNotificationsFrom = ["IT:", "Specialgroup"];
+```
+
 ### Actions to notify of
 
 MediaWiki actions that will be sent notifications of into Slack. Set desired options to false to disable notifications of those actions.

--- a/SlackNotificationsCore.php
+++ b/SlackNotificationsCore.php
@@ -113,6 +113,14 @@ class SlackNotifications
 			}
 		}
 
+		// Discard notifications from non-included pages
+		global $wgSlackIncludeNotificationsFrom;
+		if (count($wgSlackIncludeNotificationsFrom) > 0) {
+			foreach ($wgSlackIncludeNotificationsFrom as &$currentInclude) {
+				if (0 !== strpos($article->getTitle(), $currentInclude)) return;
+			}
+		}
+
 		// Skip new articles that have view count below 1. Adding new articles is already handled in article_added function and
 		// calling it also here would trigger two notifications!
 		$isNew = $status->value['new']; // This is 1 if article is new
@@ -161,6 +169,14 @@ class SlackNotifications
 			}
 		}
 
+		// Discard notifications from non-included pages
+		global $wgSlackIncludeNotificationsFrom;
+		if (count($wgSlackIncludeNotificationsFrom) > 0) {
+			foreach ($wgSlackIncludeNotificationsFrom as &$currentInclude) {
+				if (0 !== strpos($article->getTitle(), $currentInclude)) return;
+			}
+		}
+
 		// Do not announce newly added file uploads as articles...
 		if ($article->getTitle()->getNsText() == "File") return true;
 		
@@ -195,6 +211,13 @@ class SlackNotifications
 				if (0 === strpos($article->getTitle(), $currentExclude)) return;
 			}
 		}
+		// Discard notifications from non-included pages
+		global $wgSlackIncludeNotificationsFrom;
+		if (count($wgSlackIncludeNotificationsFrom) > 0) {
+			foreach ($wgSlackIncludeNotificationsFrom as &$currentInclude) {
+				if (0 !== strpos($article->getTitle(), $currentInclude)) return;
+			}
+		}
 
 		$message = sprintf(
 			"%s has deleted article %s Reason: %s",
@@ -220,6 +243,14 @@ class SlackNotifications
 			foreach ($wgSlackExcludeNotificationsFrom as &$currentExclude) {
 				if (0 === strpos($title, $currentExclude)) return;
 				if (0 === strpos($newtitle, $currentExclude)) return;
+			}
+		}
+		// Discard notifications from non-included pages
+		global $wgSlackIncludeNotificationsFrom;
+		if (count($wgSlackIncludeNotificationsFrom) > 0) {
+			foreach ($wgSlackIncludeNotificationsFrom as &$currentInclude) {
+				if (0 !== strpos($title, $currentInclude)) return;
+				if (0 !== strpos($newtitle, $currentInclude)) return;
 			}
 		}
 

--- a/extension.json
+++ b/extension.json
@@ -61,6 +61,7 @@
 		"SlackIgnoreMinorEdits": false,
 		"ExcludedPermission": "",
 		"SlackExcludeNotificationsFrom": [],
+		"SlackIncludeNotificationsFrom": [],
 		"WikiUrl": "",
 		"WikiUrlEnding": "index.php?title=",
 		"WikiUrlEndingUserRights": "Special%3AUserRights&user=",


### PR DESCRIPTION
This PR creates a new configuration variable, '$wgSlackIncludeNotificationsFrom' as an array, which serves as a converse (whitelist) of $wgSlackExcludeNotificationsFrom.  The two should be able to work together, with the Include creating a more global whitelist that the exclusion lists works on.
Simply not defining the variable should preserve previous behavior.