### PR TITLE
Replace use of deprecated Revision::getId with RevisionRecord::getId

### DIFF
--- a/SlackNotificationsCore.php
+++ b/SlackNotificationsCore.php
@@ -52,7 +52,7 @@ class SlackNotifications
 					"watch"*/);
 			if ($diff)
 			{
-				$out .= " | ".$prefix."&".$wgSlackNotificationWikiUrlEndingDiff.$article->getRevision()->getID()."|diff>)";
+				$out .= " | ".$prefix."&".$wgSlackNotificationWikiUrlEndingDiff.$article->getRevisionRecord()->getID()."|diff>)";
 			}
 			else
 			{


### PR DESCRIPTION
See https://github.com/wikimedia/mediawiki/commit/0637d805726ad8e6a8cfa581f27a33bd16436573

It's been soft deprecated since 1.31 and hard deprecated since 1.36.