### PR TITLE
Update SlackNotificationsCore.php to restore old size diff behaviour

### DIFF
--- a/SlackNotificationsCore.php
+++ b/SlackNotificationsCore.php
@@ -1,4 +1,5 @@
 <?php
+use MediaWiki\MediaWikiServices;
 class SlackNotifications
 {
 	/**
@@ -157,7 +158,7 @@ class SlackNotifications
 			if ( $wgSlackIncludeDiffSize ) {
 				$message .= sprintf(
 					" (%+d bytes)",
-					$revisionRecord->getSize());
+					$revisionRecord->getSize() - MediaWikiServices::getInstance()->getRevisionLookup()->getPreviousRevision($revisionRecord)->getSize());
 			}
 			self::push_slack_notify($message, "yellow", $user);
 		}


### PR DESCRIPTION
this restores the old size diff behaviour previously lost due to https://github.com/kulttuuri/SlackNotifications/commit/0d32dbc2fb137b1106cc495cdb164bb2b0c010b6