### PR TITLE
Fix Hook Style

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -9,46 +9,14 @@
 		"SlackNotifications": "SlackNotificationsCore.php"
 	},
 	"Hooks": {
-		"PageSaveComplete": [
-			[
-				"SlackNotifications::slack_article_saved"
-			]
-		],
-		"ArticleDeleteComplete": [
-			[
-				"SlackNotifications::slack_article_deleted"
-			]
-		],
-		"TitleMoveComplete": [
-			[
-				"SlackNotifications::slack_article_moved"
-			]
-		],
-		"AddNewAccount": [
-			[
-				"SlackNotifications::slack_new_user_account"
-			]
-		],
-		"BlockIpComplete": [
-			[
-				"SlackNotifications::slack_user_blocked"
-			]
-		],
-		"UploadComplete": [
-			[
-				"SlackNotifications::slack_file_uploaded"
-			]
-		],
-		"ArticleProtectComplete": [
-			[
-				"SlackNotifications::slack_article_protected"
-			]
-		],
-		"UserGroupsChanged": [
-			[
-				"SlackNotifications::slack_user_groups_changed"
-			]
-		]
+		"PageSaveComplete": "SlackNotifications::slack_article_saved",
+		"ArticleDeleteComplete": "SlackNotifications::slack_article_deleted",
+		"TitleMoveComplete": "SlackNotifications::slack_article_moved",
+		"AddNewAccount": "SlackNotifications::slack_new_user_account",
+		"BlockIpComplete": "SlackNotifications::slack_user_blocked",
+		"UploadComplete": "SlackNotifications::slack_file_uploaded",
+		"ArticleProtectComplete": "SlackNotifications::slack_article_protected",
+		"UserGroupsChanged": "SlackNotifications::slack_user_groups_changed"
 	},
 	"config": {
 		"SlackIncomingWebhookUrl": "",


### PR DESCRIPTION
This fixes the style for hooks in extensions.json, which previously threw a DeprecationWarning:

Deprecated</b>:  Deprecated handler style for hook 'PageSaveComplete': callable wrapped in array (SlackNotifications::slack_article_saved) [Called from MediaWiki\HookContainer\HookContainer::getHandlers in /var/www/html/includes/HookContainer/HookContainer.php at line 523] in <b>/var/www/html/includes/debug/MWDebug.php</b> on line <b>379</b><br/>

This error was causing VisualEditor to throw an error on every save, which is now fixed :slightly_smiling_face: 